### PR TITLE
Git commit support

### DIFF
--- a/ftdetect/github.vim
+++ b/ftdetect/github.vim
@@ -2,6 +2,18 @@
 "
 " Maintainer: Jake Zimmerman <jake@zimmerman.io>
 
+let s:types = ['pull', 'commit', 'issue', 'release']
+
+let s:pull_filename = 'PULLREQ_EDITMSG'
+let s:commit_filename = 'COMMIT_EDITMSG'
+let s:issue_filename = 'ISSUE_EDITMSG'
+let s:release_filename = 'RELEASE_EDITMSG'
+
+let s:pull_filetype = 'ghpull'
+let s:commit_filetype = 'ghcommit'
+let s:issue_filetype = 'ghissue'
+let s:release_filetype = 'ghrelease'
+
 " I like using vim-pandoc-syntax for Markdown syntax highlighting, so let's
 " detect if it's installed and fall back to normal markdown if it's not.
 if &runtimepath =~# 'vim-pandoc-syntax'
@@ -13,12 +25,16 @@ end
 " Override the 'gitcommit' filetype that the hub tool sets with a compound
 " markdown + gh(pull|issue) filetype.
 function! s:overrideHubFiletype()
-  if expand('%:t') ==# 'PULLREQ_EDITMSG'
-    exe 'setlocal filetype=' .s:markdown .'.ghpull'
-  elseif expand('%:t') ==# 'ISSUE_EDITMSG'
-    exe 'setlocal filetype=' .s:markdown .'.ghissue'
-  elseif expand('%:t') ==# 'RELEASE_EDITMSG'
-    exe 'setlocal filetype=' .s:markdown .'.ghrelease'
+  let l:filename = expand('%:t')
+
+  for l:type in s:types
+    if l:filename ==# s:{l:type}_filename
+      let l:filetype = s:{l:type}_filetype
+    endif
+  endfor
+
+  if exists('l:filetype')
+    execute 'setlocal filetype=' . s:markdown . '.' . l:filetype
   endif
 endfunction
 
@@ -30,7 +46,9 @@ augroup VimGitHubHubFtDetect
   autocmd FileType gitcommit call s:overrideHubFiletype()
 
   " In case they stop doing what they're currently doing at some point
-  exe 'autocmd BufRead,BufNewFile PULLREQ_EDITMSG setlocal filetype='.s:markdown.'.ghpull'
-  exe 'autocmd BufRead,BufNewFile ISSUE_EDITMSG setlocal filetype='.s:markdown.'.ghissue'
-  exe 'autocmd BufRead,BufNewFile RELEASE_EDITMSG setlocal filetype='.s:markdown.'.ghrelease'
+  for s:type in s:types
+    execute 'autocmd BufRead,BufNewFile ' .
+      \ s:{s:type}_filename . ' setlocal filetype=' .
+      \ s:markdown . '.' . s:{s:type}_filetype
+  endfor
 augroup END

--- a/syntax/ghcommit.vim
+++ b/syntax/ghcommit.vim
@@ -1,6 +1,12 @@
-runtime syntax/ghhub.vim
+try
+  runtime syntax/ghhub.vim
+catch
+  finish
+endtry
 
-unlet b:current_syntax
+if exists('b:current_syntax')
+  unlet b:current_syntax
+endif
 
 syntax include @gitcommit syntax/gitcommit.vim
 syntax region gitcommit start=/\%(^diff --\%(git\|cc\|combined\) \)\@=/ end=/^\%(diff --\|$\|#\)\@=/ fold contains=@gitcommit

--- a/syntax/ghcommit.vim
+++ b/syntax/ghcommit.vim
@@ -1,0 +1,6 @@
+runtime syntax/ghhub.vim
+
+unlet b:current_syntax
+
+syntax include @gitcommit syntax/gitcommit.vim
+syntax region gitcommit start=/\%(^diff --\%(git\|cc\|combined\) \)\@=/ end=/^\%(diff --\|$\|#\)\@=/ fold contains=@gitcommit

--- a/syntax/ghhub.vim
+++ b/syntax/ghhub.vim
@@ -1,8 +1,6 @@
 " Vim syntax file
 "
 " Maintainer: Jake Zimmerman <jake@zimmerman.io
-"
-" TODO(jez): Highlight commit messages the way hub puts them in
 
 syn case match
 syn sync minlines=50
@@ -18,7 +16,23 @@ function! s:getCommentChar()
     return [l:line[0], 'region']
   endif
 
-  let l:line = getline(search('\v(Creating issue|Creating release|Requesting a pull)', 'nw'))
+  let l:issueMatch = 'Creating issue'
+  let l:pullMatch = 'Requesting a pull'
+  let l:commitMatch = 'Please enter the commit message'
+  let l:releaseMatch = 'Creating release'
+
+  let l:line = getline(search(
+    \ '\v(' .
+    \ l:issueMatch .
+    \ '|' .
+    \ l:pullMatch .
+    \ '|' .
+    \ l:commitMatch .
+    \ '|' .
+    \ l:releaseMatch .
+    \ ')'
+    \ , 'nw'))
+
   if strlen(l:line) > 0
     return [l:line[0], 'line']
   endif


### PR DESCRIPTION
- Add `ghcommit` filetype that inherits settings from `ghhub`
- Ensure diffs included in commit comment instructions are still highlighted correctly
- Update Git `commentChar` detection to include commit message default comment (probably can just pull that from Git settings? 😬)
- A bit of (opiniated?) code format changes

<img width="787" alt="ghcommit" src="https://user-images.githubusercontent.com/288160/31038095-b2c12572-a529-11e7-9689-48f4d35a342f.png">